### PR TITLE
Fix indexing for tnorm application in membership function in rules.py

### DIFF
--- a/ex_fuzzy/ex_fuzzy/rules.py
+++ b/ex_fuzzy/ex_fuzzy/rules.py
@@ -132,11 +132,13 @@ class Rule():
         :param x: input to compute the membership.
         :param tnorm: t-norm to use in the inference process.
         '''
+        if x.ndim == 1:
+            x = x.reshape(1, -1)
         for ix, antecedent in enumerate(self.antecedents):
             if ix == 0:
-                res = antecedent.membership(x)
+                res = antecedent.membership(x[:,ix])
             else:
-                res = tnorm(res, antecedent.membership(x))
+                res = tnorm(res, antecedent.membership(x[:,ix]))
 
         return res
 


### PR DESCRIPTION
In each iteration, all the attributes were evaluated for the given antecedent (antecedent.membership(x)), and only the corresponding one x[:, ix] should be evaluated. I have also added a check for the case where only one input is evaluated.